### PR TITLE
Use native package managers

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -95,7 +95,7 @@ runs:
           choco install llvm --version=13.0.1 --force
           # choco install llvm --version=${{ inputs.version }} -y
         elif [[ "${{runner.os}}"  == "macOS" ]]; then
-          homebrew install clang-format clang-tidy
+          brew install clang-format clang-tidy
         fi
     - name: Install action dependencies
       shell: bash


### PR DESCRIPTION
* Version History https://community.chocolatey.org/packages/llvm#versionhistory

Notes: brew does not support install clang-tidy
```
Run if [[ "macOS"  == "Linux" ]]; then
Warning: No available formula with the name "clang-tidy". Did you mean clang-format?
==> Searching for similarly named formulae...
This similarly named formula was found:
```