### PR TITLE
Pinning action to certain version of clang-tools

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -87,7 +87,7 @@ runs:
   steps:
     - name: Install action dependencies
       shell: bash
-      run: python3 -m pip install clang-tools cpp-linter==1.4.8
+      run: python3 -m pip install clang-tools==0.6.2 cpp-linter==1.4.8
     - name: Install clang-tools binary executables
       shell: bash
       run: clang-tools -i ${{ inputs.version }} -b


### PR DESCRIPTION
To pin action to a certain version of clang-tools and release `v2.1.2`