### PR TITLE
Pin v1 to use cpp-linter `v1.4.9`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,6 @@ import setuptools
 setuptools.setup(
     name="cpp-linter-deprecated",
     version="0.0.0",
-    install_requires=["cpp-linter"],
+    install_requires=["cpp-linter==1.4.9"],
     py_modules=[""],
 )


### PR DESCRIPTION
This also include fix https://github.com/cpp-linter/cpp-linter-action/issues/108 to `v1` version