### PR TITLE
use native package managers for linux runner

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -90,7 +90,7 @@ runs:
       run: |
         if [[ "${{runner.os}}"  == "Linux" ]]; then
           sudo apt-get update
-          sudo apt-get install clang-format-${{ inputs.version }} clang-tidy-${{ inputs.version }}
+          sudo apt-get install clang-format-${{ inputs.version }} clang-tidy-${{ inputs.version }} || true
         fi
         if [[ "${{runner.os}}"  == "macOS" ]];then
           python3 -m venv '${{ github.action_path }}/venv'


### PR DESCRIPTION
Fix https://github.com/cpp-linter/cpp-linter-action/issues/106

Right now this only supports Linux runner 

Why do not support macOS and windows runner because the following reasons:

on macOS, brew only supports a few versions of clang-format and does not support clang-tidy right now

```
Run if [[ "macOS"  == "Linux" ]]; then
Warning: No available formula with the name "clang-tidy". Did you mean clang-format?
==> Searching for similarly named formulae...
This similarly named formula was found:
```

on windows chocolatey support installing both clang-format and clang-tidy but the version is different with user input. for example when the user input `13` in the cpp-linter.yml etc, we need to match this version from `13` to `13.0.1` otherwise can not find and install clang 13 on windows. we also need to match for other versions if we support them, but it would be best to do it like in a setup-action.sh script file. right now I think it should be enough we only support linux.