### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
* `dependabot` can help us to automatically bump cpp-linter and create Pull request when there is a new release
* it also can help to keep github-actions updated to date

It's probably not really must have, but it might save some work.