### PR TITLE
Run LLVM install script on Linux runners

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -89,6 +89,10 @@ runs:
       shell: bash
       run: |
         if [[ "${{runner.os}}"  == "Linux" ]]; then
+          # This LLVM script will add the relevant LLVM PPA: https://apt.llvm.org/
+          wget https://apt.llvm.org/llvm.sh -O $GITHUB_ACTION_PATH/llvm_install.sh
+          chmod +x $GITHUB_ACTION_PATH/llvm_install.sh
+          sudo $GITHUB_ACTION_PATH/llvm_install.sh ${{ inputs.version }} || true
           sudo apt-get update
           sudo apt-get install clang-format-${{ inputs.version }} clang-tidy-${{ inputs.version }} || true
         fi


### PR DESCRIPTION
This will add the relevant LLVM PPA to the runner's package manager which provides versions of clang-format and clang-tidy that may not yet be available in the official Ubuntu repositories (e.g. LLVM 16 on Ubuntu 22.04 at the time this commit was authored).

This resolves #145.