### PR TITLE
Added clang v16 to README and action description #145

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ jobs:
 
 #### `version`
 
-- **Description**: The desired version of the [clang-tools](https://github.com/cpp-linter/clang-tools-pip) to use. Accepted options are strings which can be 16, 15, 14, 13, 12, 11, 10, 9, or 8.
+- **Description**: The desired version of the [clang-tools](https://github.com/cpp-linter/clang-tools-pip) to use. Accepted options are strings which can be 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4 or 3.9.
     - Set this option to a blank string (`''`) to use the platform's default installed version.
     - This value can also be a path to where the clang tools are installed (if using a custom install location).
 - Default: '12'

--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ inputs:
     required: false
     default: "."
   version:
-    description: "The desired version of the clang tools to use. Accepted options are strings which can be 16, 15, 14, 13, 12, 11, 10, 9, or 8. Defaults to 12."
+    description: "The desired version of the clang tools to use. Accepted options are strings which can be 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4 or 3.9. Defaults to 12."
     required: false
     default: "12"
   verbosity:


### PR DESCRIPTION
I also removed 7, 6, 5, 4, or 3.9. from README.md to keep the same as it is in action.yml. Even though we support these versions, I think most users will not use them.