### PR TITLE
add `-y` to any `apt-get install` commands

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -91,12 +91,12 @@ runs:
         if [[ "${{runner.os}}"  == "Linux" ]]; then
           sudo apt-get update
           # First try installing from default Ubuntu repositories before trying LLVM script
-          if ! sudo apt-get install clang-format-${{ inputs.version }} clang-tidy-${{ inputs.version }}; then
+          if ! sudo apt-get install -y clang-format-${{ inputs.version }} clang-tidy-${{ inputs.version }}; then
             # This LLVM script will add the relevant LLVM PPA: https://apt.llvm.org/
             wget https://apt.llvm.org/llvm.sh -O $GITHUB_ACTION_PATH/llvm_install.sh
             chmod +x $GITHUB_ACTION_PATH/llvm_install.sh
             if sudo $GITHUB_ACTION_PATH/llvm_install.sh ${{ inputs.version }}; then
-              sudo apt-get install clang-format-${{ inputs.version }} clang-tidy-${{ inputs.version }}
+              sudo apt-get install -y clang-format-${{ inputs.version }} clang-tidy-${{ inputs.version }}
             fi
           fi
         fi


### PR DESCRIPTION
I checked the LLVM install script, and it already uses `apt-get install -y`. So this should resolve #148