### PR TITLE
change `${{ github.action_path }}` with `$GITHUB_ACTION_PATH`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -111,18 +111,18 @@ runs:
           fi
         fi
         if [[ "${{runner.os}}"  == "macOS" ]]; then
-          python3 -m venv '${{ github.action_path }}/venv'
-          source '${{ github.action_path }}/venv/bin/activate'
+          python3 -m venv "$GITHUB_ACTION_PATH/venv"
+          source "$GITHUB_ACTION_PATH/venv/bin/activate"
         fi
-        python3 -m pip install -r '${{ github.action_path }}/requirements.txt'
+        python3 -m pip install -r "$GITHUB_ACTION_PATH/requirements.txt"
         clang-tools -i ${{ inputs.version }} -b
 
     - name: Run cpp-linter
       id: cpp-linter
       shell: bash
       run: |
-        if [[ "${{runner.os}}"  == "macOS" ]];then
-          source '${{ github.action_path }}/venv/bin/activate'
+        if [[ "${{runner.os}}"  == "macOS" ]]; then
+          source "$GITHUB_ACTION_PATH/venv/bin/activate"
         fi
         cpp-linter \
           --style="${{ inputs.style }}" \


### PR DESCRIPTION
Hi! Super great action, kudos for all the work!

We noticed that, when using this action inside a custom container, `${{ github.action_path }}` is not properly set up. Instead, `$GITHUB_ACTION_PATH` is set up as expected (it's already being used in this action, there should not be difference). Github seem to be tracking this issue https://github.com/actions/runner/issues/2185 but they didn't merged the fix yet.
This change should not change the functionality for anyone.

Thanks @2bndy5 and all the team for the hard work!