### PR TITLE
update cpp-linter dependency to v1.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,19 @@ jobs:
 
 ### Outputs
 
-This action creates 1 output variable named `checks-failed`. Even if the linting checks fail for source files this action will still pass, but users' CI workflows can use this action's output to exit the workflow early if that is desired.
+This action creates 3 output variables. Even if the linting checks fail for source files this action will still pass, but users' CI workflows can use this action's outputs to exit the workflow early if that is desired.
+
+#### `checks-failed`
+
+The total number of concerns raised by both clang-format and clang-tidy.
+
+#### `clang-tidy-checks-failed`
+
+The total number of concerns raised by clang-tidy only.
+
+#### `clang-format-checks-failed`
+
+The total number of concerns raised by clang-format only.
 
 ## Example
 

--- a/action.yml
+++ b/action.yml
@@ -101,8 +101,14 @@ inputs:
     default: ""
 outputs:
   checks-failed:
-    description: An integer that can be used as a boolean value to indicate if all checks failed.
+    description: An integer that can be used as a boolean value to indicate if any checks failed by clang-tidy and clang-format.
     value: ${{ steps.cpp-linter.outputs.checks-failed }}
+  clang-tidy-checks-failed:
+    description: An integer that can be used as a boolean value to indicate if any checks failed by clang-tidy only.
+    value: ${{ steps.cpp-linter.outputs.clang-tidy-checks-failed }}
+  clang-format-checks-failed:
+    description: An integer that can be used as a boolean value to indicate if any checks failed by clang-format only.
+    value: ${{ steps.cpp-linter.outputs.clang-format-checks-failed }}
 runs:
   using: "composite"
   steps:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ clang-tools==0.9.0
 
 # cpp-linter core Python executable package
 # For details please see: https://github.com/cpp-linter/cpp-linter
-cpp-linter==1.6.1
+cpp-linter==1.6.2


### PR DESCRIPTION
resolves #168

adds 2 new output variables:
- `clang-tidy-checks-failed`
- `clang-format-checks-failed`