### PR TITLE
fix: expose python libraries

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -117,7 +117,6 @@ runs:
       id: setup-python
       with:
         python-version: '3.11'
-        update-environment: false
 
     - name: Install Linux clang dependencies
       if: runner.os == 'Linux'


### PR DESCRIPTION
When `update-environment` is false, setup-python does not export LD_LIBRARY_PATH and PKG_CONFIG_PATH variables, which are required to find properly `libpython.so` and this kind of libs. Without this change, it's required to have the `libpython311.so` already installed in the system, that kinda breaks the purpose of using setup-python.
Thanks for the great work you do!