### PR TITLE
use python version shipped with Ubuntu 22.04

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -116,7 +116,8 @@ runs:
       uses: actions/setup-python@v5
       id: setup-python
       with:
-        python-version: '3.11'
+        # use python version shipped with latest Ubuntu LTS
+        python-version: '3.10'
         update-environment: false
 
     - name: Install Linux clang dependencies


### PR DESCRIPTION
As proposed in #185, we'll start pinning python version to what is included with Ubuntu latest LTS. Currently, Ubuntu 22.04 ships with python v3.10