### PR TITLE
change token to GITHUB_TOKEN for release drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,7 +10,7 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      # Drafts your next Release notes as Pull Requests are merged into the default branch
+      # Draft your next Release notes as Pull Requests are merged into the default branch
       - uses: release-drafter/release-drafter@v5
         env:
-          GITHUB_TOKEN: ${{ secrets.CPP_LINTER_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The current [drafted release](https://github.com/cpp-linter/cpp-linter-action/releases/tag/untagged-a59a30df09792158cd5c) was always created by me because I created the personal token from my account. 

I changed the token from `CPP_LINTER_TOKEN` to `GITHUB_TOKEN` in my fork repo, and it seems to work.

<img width="422" alt="image" src="https://github.com/cpp-linter/cpp-linter-action/assets/3353385/ffff9355-4793-4418-a951-a5636760ecdd">
