### PR TITLE
Support clang-tools version 18

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: C/C++ Linter
-description: Lint C/C++ code with clang-format and clang-tidy then post annotations, comments, and step summary with results.
-author: shenxianpeng
+description: Linting C/C++ code integrating clang-tidy and clang-format to collect feedback provided in the form of file-annotations, thread-comments, workflow step-summary, and Pull Request reviews.
+author: cpp-linter
 branding:
   icon: "check-circle"
   color: "green"
@@ -58,7 +58,7 @@ inputs:
     required: false
     default: "."
   version:
-    description: "The desired version of the clang tools to use. Accepted options are strings which can be 17, 16, 15, 14, 13, 12, 11, 10, 9, 8 or 7. Defaults to 12."
+    description: "The desired version of the clang tools to use. Accepted options are strings which can be 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8 or 7. Defaults to 12."
     required: false
     default: "12"
   verbosity:

--- a/docs/inputs-outputs.md
+++ b/docs/inputs-outputs.md
@@ -43,7 +43,7 @@ The relative path to the repository root directory. This path is relative to the
 <!-- md:version 1.2.0 -->
 <!-- md:default 12 -->
 
-The desired version of the [clang-tools](https://github.com/cpp-linter/clang-tools-pip) to use. Accepted options are strings which can be 17, 16, 15, 14, 13, 12, 11, 10, 9, 8 or 7.
+The desired version of the [clang-tools](https://github.com/cpp-linter/clang-tools-pip) to use. Accepted options are strings which can be 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8 or 7.
 
 - Set this option to a blank string (`''`) to use the platform's default installed version.
 - This value can also be a path to where the clang tools are installed (if using a custom install location).


### PR DESCRIPTION
In addition to #203, I also made the following changes. 

* update description, add clang-tools v18 to action.yml
* add clang-tools v18 to inputs-outputs.md
* Follow up #60, change author from `shenxianpeng` to `cpp-linter` in action.yml after transfer.