### PR TITLE
update dependabot.yml to bump group updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,15 @@ updates:
     directory: /
     schedule:
       interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"
   - package-ecosystem: pip
     directory: /
     schedule:
       interval: "daily"
+    groups:
+      pip:
+        patterns:
+          - "*"


### PR DESCRIPTION
Use `groups` in dependabot.yml to open a single pull request to update multiple dependencies at the same time.

For example https://github.com/cpp-linter/clang-tools-docker/pull/72