### PR TITLE
Docs typo

### DIFF
--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -18,6 +18,9 @@ on:
 
 jobs:
   test:
+    permissions:
+      issues: write
+      pull-requests: write
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
@@ -61,7 +64,8 @@ jobs:
         # if: steps.linter.outputs.checks-failed > 0
         run: |
           echo "some linter checks failed"
-          echo "${{ steps.linter.outputs.checks-failed }}"
-          echo "${{ env.checks-failed }}"
+          echo "total checks-failed: ${{ steps.linter.outputs.checks-failed }}"
+          echo "clang-tidy checks-failed: ${{ steps.linter.outputs.clang-tidy-checks-failed }}"
+          echo "clang-format checks-failed: ${{ steps.linter.outputs.clang-format-checks-failed }}"
         # for actual deployment
         # run: exit 1

--- a/docs/action.yml
+++ b/docs/action.yml
@@ -36,10 +36,10 @@ inputs:
   tidy-review:
     experimental: true
     minimum-version: '2.9.0'
-    required-permission: 'pull_request: write #pull-request-reviews'
+    required-permission: 'pull-requests: write #pull-request-reviews'
   format-review:
     minimum-version: '2.9.0'
-    required-permission: 'pull_request: write #pull-request-reviews'
+    required-permission: 'pull-requests: write #pull-request-reviews'
 outputs:
   checks-failed:
     minimum-version: '1.2.0'

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -29,7 +29,7 @@ The [`thread-comments`](inputs-outputs.md#thread-comments) feature requires the 
 ```yaml
     permissions:
       issues: write # (1)!
-      pull_requests: write # (2)!
+      pull-requests: write # (2)!
 ```
 
 1. for [push events](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push)
@@ -41,5 +41,5 @@ The [`tidy-review`](inputs-outputs.md#tidy-review) and [`format-review`](inputs-
 
 ```yaml
     permissions:
-      pull_requests: write
+      pull-requests: write
 ```


### PR DESCRIPTION
- fix a docs typo about `pull-requests` permissions
- add write permissions to token in self-test CI
- improve self-test CI step that shows `*checks-failed` outputs