### PR TITLE
python venv cache support

### DIFF
--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -57,6 +57,7 @@ jobs:
         with:
           style: file
           files-changed-only: false
+          cache: true
           # to ignore all build folder contents
           ignore: build|venv
           database: build

--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,11 @@ inputs:
       [re-running jobs or workflows](https://docs.github.com/en/actions/managing-workflow-runs/re-running-workflows-and-jobs).
     required: false
     default: info
+  cache:
+    description: |
+      This controls if the python virtual environment is cached.
+    required: false
+    default: false
   lines-changed-only:
     description: |
       This controls what part of the files are analyzed. The following values are accepted:
@@ -233,6 +238,22 @@ runs:
             sudo apt-get install -y clang-format-${{ inputs.version }} clang-tidy-${{ inputs.version }}
           fi
         fi
+
+    - if: ${{ inputs.cache == 'true' }}
+      id: gen-cache-key
+      shell: python
+      run: |
+        import hashlib, os, pathlib
+        fp = pathlib.Path(os.path.join(os.environ["GITHUB_ACTION_PATH"], 'requirements.txt'))
+        with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+          print('hash=%s' % (hashlib.sha1(fp.read_bytes()).hexdigest()), file=f)
+
+    - uses: actions/cache@v4
+      if: ${{ inputs.cache == 'true' }}
+      with:
+        key: cpp-linter-action-venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ steps.gen-cache-key.outputs.hash }}
+        restore-keys: cpp-linter-action-venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-
+        path: ${{ github.action_path }}/venv
 
     - name: Setup python venv (Unix)
       if: runner.os == 'Linux' || runner.os == 'macOS'


### PR DESCRIPTION
`hashFiles` [currently doesn't support globs outside of the GITHUB_WORKSPACE](https://github.com/actions/toolkit/issues/1035). This works around the limitation.