### PR TITLE
Update used-by.yml to explicit author

### DIFF
--- a/.github/workflows/used-by.yml
+++ b/.github/workflows/used-by.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           add-paths: "README.md" # the file path to commit
           commit-message: "chore: update used-by badge by github-actions[bot]"
-          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           title: "chore: automatically update used-by badge"
           base: main
           labels: skip-changelog


### PR DESCRIPTION
I am not sure why every used-by pull request has my user commit. see #279 

It may have used my personal token somewhere but I don't see it. Maybe I need to explicit `committer`? Just a try.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow to specify pull request author as GitHub Actions bot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->