### PR TITLE
chore: update dependency config to monitor multiple locations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directories:
-      - ".github/workflows"
+      - "/"
       - "docs/examples"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Address https://github.com/cpp-linter/cpp-linter-action/pull/302#issuecomment-3177654094

We can use [`directories`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/controlling-dependencies-updated#defining-multiple-locations-for-manifest-files) to update github-actions files across multiple locations

But the only issue is that we can not test the action from `docs/examples` folder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded dependency automation to cover additional areas of the project, ensuring broader and more timely updates across workflows and example assets.
  * Kept update cadence, grouping rules, and dependency types unchanged to avoid unexpected behavior.
  * Improves maintenance reliability and security of automated updates without affecting application features or user workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->