### PR TITLE
Bump actions/checkout from 4 to 5

### DIFF
--- a/.github/workflows/examples/only-PR-comments.yml
+++ b/.github/workflows/examples/only-PR-comments.yml
@@ -13,7 +13,7 @@ jobs:
     permissions: # (1)!
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # ... optionally setup build env to create a compilation database
 

--- a/.github/workflows/examples/only-clang-format.yml
+++ b/.github/workflows/examples/only-clang-format.yml
@@ -11,7 +11,7 @@ jobs:
   cpp-linter:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # ... optionally setup build env to create a compilation database
 

--- a/.github/workflows/examples/only-clang-tidy.yml
+++ b/.github/workflows/examples/only-clang-tidy.yml
@@ -11,7 +11,7 @@ jobs:
   cpp-linter:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # ... optionally setup build env to create a compilation database
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The content of the file should be in the following format.
 
 ```yaml
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: cpp-linter/cpp-linter-action@v2
         id: linter
         env:


### PR DESCRIPTION
Not sure why #304 also does not work as expected to bump `actions/checkout` from 4 to 5 automaticlly

Maybe we should bump it manually and include README.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded GitHub Actions checkout step to v5 across example workflows for improved compatibility and security.
- **Documentation**
  - Updated README examples to reference checkout v5, ensuring instructions match the latest workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->