### PR TITLE
docs: update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD033 MD041-->
+
 [file-annotations]: https://cpp-linter.github.io/cpp-linter-action/inputs-outputs/#file-annotations
 [thread-comments]: https://cpp-linter.github.io/cpp-linter-action/inputs-outputs/#thread-comments
 [step-summary]: https://cpp-linter.github.io/cpp-linter-action/inputs-outputs/#step-summary
@@ -37,12 +39,6 @@ workflow [`step-summary`][step-summary], and Pull Request reviews (with
 > MacOS and Windows runners are supported as well.
 
 ## Usage
-
-> [!NOTE]
-> Python 3.10 needs to be installed in the docker image if your workflow is
-> [running jobs in a container](https://docs.github.com/en/actions/using-jobs/running-jobs-in-a-container)
-> (see discussion in [#185](https://github.com/cpp-linter/cpp-linter-action/issues/185)).
-> Our intention is to synchronize with the default Python version included with Ubuntu's latest LTS releases.
 
 Create a new GitHub Actions workflow in your project, e.g. at [.github/workflows/cpp-linter.yml](https://github.com/cpp-linter/cpp-linter-action/blob/main/.github/workflows/cpp-linter.yml)
 


### PR DESCRIPTION
follow-up to #306

Python is no longer required to be installed on the runner anymore.
`uv sync` will automatically download the latest supported stable version of Python.

This just removes a note about this in the README.

it also disables a few markdown lint rules that are violated (raw HTML used and first line is not the h1 title).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README formatting by disabling specific markdownlint rules (MD033, MD041).
  * Removed outdated Usage section, including notes about Python 3.10 in the Docker image and container usage guidance.
  * Removed reference to an external discussion and the instruction to create a GitHub Actions workflow.
  * Clarified that no code or public API changes are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->