### PR TITLE
fix: venv usage

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -309,13 +309,30 @@ runs:
             ^curl -LsSf $"https://astral.sh/uv/($env.UV_VERSION)/install.sh" | sh
         }
 
+        let gh_action_debug = $env | get --optional 'ACTIONS_STEP_DEBUG'
+        let action_verbosity = '${{ inputs.verbosity }}' == 'debug'
+        let verbosity = (
+            $action_verbosity
+            or ($gh_action_debug == true)
+            or ($gh_action_debug == 'true')
+        )
+
+        mut uv_args = [sync --project $action_path --group action]
+        if $verbosity {
+          $uv_args = $uv_args | append '-v'
+        }
+
         print $"\n(ansi purple)Installing workflow dependencies(ansi reset)"
-        ^$'($env.UV_INSTALL_DIR)/uv' sync -v --project $action_path --group action
+        ^$'($env.UV_INSTALL_DIR)/uv' ...$uv_args
+
+        let cmd = [clang-tools -i ${{ inputs.version }} -b]
+        $uv_args = [run --no-sync --project $action_path --directory (pwd)]
+        if $verbosity {
+            $uv_args = $uv_args | append '-v'
+        }
 
         print $"\n(ansi purple)Ensuring clang-format and clang-tidy ${{ inputs.version }} are present(ansi reset)"
-        let cmd = [clang-tools -i ${{ inputs.version }} -b]
-        let uv_args = [run --no-sync --project $action_path --directory (pwd)]
-        ^$'($env.UV_INSTALL_DIR)/uv' -v ...$uv_args ...$cmd
+        ^$'($env.UV_INSTALL_DIR)/uv' ...$uv_args ...$cmd
 
     - name: Run cpp-linter
       id: cpp-linter
@@ -348,7 +365,18 @@ runs:
             --passive-reviews="${{ inputs.passive-reviews }}"
             --jobs=${{ inputs.jobs }}
         ]
+        mut uv_args = [run --no-sync --project $action_path --directory (pwd)]
+
+        let gh_action_debug = $env | get --optional 'ACTIONS_STEP_DEBUG'
+        let action_verbosity = '${{ inputs.verbosity }}' == 'debug'
+        let verbosity = (
+            $action_verbosity
+            or ($gh_action_debug == true)
+            or ($gh_action_debug == 'true')
+        )
+        if $verbosity {
+            $uv_args = $uv_args | append '-v'
+        }
 
         print $"\n(ansi purple)Running cpp-linter(ansi reset)"
-        let uv_args = [run --no-sync --project $action_path --directory (pwd)]
-        ^$'($env.UV_INSTALL_DIR)/uv' ...$uv_args -v cpp-linter ...$args
+        ^$'($env.UV_INSTALL_DIR)/uv' ...$uv_args cpp-linter ...$args

--- a/action.yml
+++ b/action.yml
@@ -296,7 +296,6 @@ runs:
       run: |-
         let action_path = $env.GITHUB_ACTION_PATH | path expand
         $env.UV_INSTALL_DIR = $action_path | path join 'bin'
-        $env.UV_PROJECT_ENVIRONMENT = $action_path | path join '.venv'
 
         $env.UV_CACHE_DIR = $env.RUNNER_TEMP | path join 'cpp-linter-action-cache'
         if (not ($env.UV_CACHE_DIR | path exists)) {
@@ -311,10 +310,12 @@ runs:
         }
 
         print $"\n(ansi purple)Installing workflow dependencies(ansi reset)"
-        ^$'($env.UV_INSTALL_DIR)/uv' sync --directory $action_path --group action
+        ^$'($env.UV_INSTALL_DIR)/uv' sync -v --project $action_path --group action
 
         print $"\n(ansi purple)Ensuring clang-format and clang-tidy ${{ inputs.version }} are present(ansi reset)"
-        ^$'($env.UV_INSTALL_DIR)/uv' run clang-tools -i ${{ inputs.version }} -b
+        let cmd = [clang-tools -i ${{ inputs.version }} -b]
+        let uv_args = [run --no-sync --project $action_path --directory (pwd)]
+        ^$'($env.UV_INSTALL_DIR)/uv' -v ...$uv_args ...$cmd
 
     - name: Run cpp-linter
       id: cpp-linter
@@ -322,7 +323,6 @@ runs:
       run: |-
         let action_path = $env.GITHUB_ACTION_PATH | path expand
         $env.UV_INSTALL_DIR = $action_path | path join 'bin'
-        $env.UV_PROJECT_ENVIRONMENT = $action_path | path join '.venv'
         $env.UV_CACHE_DIR = $env.RUNNER_TEMP | path join 'cpp-linter-action-cache'
 
         let args = [
@@ -350,4 +350,5 @@ runs:
         ]
 
         print $"\n(ansi purple)Running cpp-linter(ansi reset)"
-        ^$'($env.UV_INSTALL_DIR)/uv' run cpp-linter ...$args
+        let uv_args = [run --no-sync --project $action_path --directory (pwd)]
+        ^$'($env.UV_INSTALL_DIR)/uv' ...$uv_args -v cpp-linter ...$args


### PR DESCRIPTION
related to #305
intended to resolve #313 

### Summary

Apparently, `uv` only respects the `UV_PROJECT_ENVIRONMENT` env var for only certain `uv` commands.

This workaround involves a combination of `--project` and `--directory`:
```
uv run --project $GITHUB_ACTION_PATH --directory (pwd)
```
Where `(pwd)` is the nushell builtin command similar to bash's `$(pwd)` and should point to the working directory.