### PR TITLE
fix: only update tag for a released type event

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   release:
     branches: [main]
-    types: [published]
+    types: [released]
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
Right now, if we published a pre-release, the tag `v2` will also be updated to point to the pre-release. which is not what we wanted. 

We should change the type to [released](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#release)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated release automation to run only on finalized releases, ensuring artifacts and notifications are generated at the correct stage. This improves consistency and reduces premature triggers during the release process. No changes to product features or UI, but users may notice more predictable release timing and availability across distribution channels. No action required from users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->