### PR TITLE
fix: pass inputs as uninterpretted strings

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -369,7 +369,7 @@ runs:
         )
 
         print $"\n(ansi purple)Installing workflow dependencies(ansi reset)"
-        mut uv_args = [sync --project $action_path --group action --no-dev]
+        mut uv_args = [sync --project $action_path --group action --no-dev --link-mode=copy]
         if $verbosity {
           $uv_args = $uv_args | append '-v'
         }

--- a/action.yml
+++ b/action.yml
@@ -393,26 +393,26 @@ runs:
 
         let args = [
           '--style=${{ inputs.style }}'
-          --extensions '${{ inputs.extensions }}'
+          '--extensions=${{ inputs.extensions }}'
           '--tidy-checks=${{ inputs.tidy-checks }}'
-          --repo-root ${{ inputs.repo-root }}
-          --version ${{ inputs.version }}
-          --verbosity ${{ inputs.verbosity }}
-          --lines-changed-only ${{ inputs.lines-changed-only }}
-          --files-changed-only ${{ inputs.files-changed-only }}
-          --thread-comments ${{ inputs.thread-comments }}
-          --no-lgtm ${{ inputs.no-lgtm }}
-          --step-summary ${{ inputs.step-summary }}
+          '--repo-root=${{ inputs.repo-root }}'
+          '--version=${{ inputs.version }}'
+          '--verbosity=${{ inputs.verbosity }}'
+          '--lines-changed-only=${{ inputs.lines-changed-only }}'
+          '--files-changed-only=${{ inputs.files-changed-only }}'
+          '--thread-comments=${{ inputs.thread-comments }}'
+          '--no-lgtm=${{ inputs.no-lgtm }}'
+          '--step-summary=${{ inputs.step-summary }}'
           '--ignore=${{ inputs.ignore }}'
           '--ignore-tidy=${{ inputs.ignore-tidy }}'
           '--ignore-format=${{ inputs.ignore-format }}'
-          --database ${{ inputs.database }}
-          --file-annotations ${{ inputs.file-annotations }}
+          '--database=${{ inputs.database }}'
+          '--file-annotations=${{ inputs.file-annotations }}'
           '--extra-arg=${{ inputs.extra-args }}'
-          --tidy-review ${{ inputs.tidy-review }}
-          --format-review ${{ inputs.format-review }}
-          --passive-reviews ${{ inputs.passive-reviews }}
-          --jobs ${{ inputs.jobs }}
+          '--tidy-review=${{ inputs.tidy-review }}'
+          '--format-review=${{ inputs.format-review }}'
+          '--passive-reviews=${{ inputs.passive-reviews }}'
+          '--jobs=${{ inputs.jobs }}'
         ]
         mut uv_args = [run --no-sync --project $action_path --directory (pwd)]
 

--- a/action.yml
+++ b/action.yml
@@ -369,7 +369,7 @@ runs:
         )
 
         print $"\n(ansi purple)Installing workflow dependencies(ansi reset)"
-        mut uv_args = [sync --project $action_path --group action]
+        mut uv_args = [sync --project $action_path --group action --no-dev]
         if $verbosity {
           $uv_args = $uv_args | append '-v'
         }
@@ -392,27 +392,27 @@ runs:
         $env.UV_CACHE_DIR = $env.RUNNER_TEMP | path join 'cpp-linter-action-cache'
 
         let args = [
-          --style="${{ inputs.style }}"
-          --extensions=${{ inputs.extensions }}
-          --tidy-checks="${{ inputs.tidy-checks }}"
-          --repo-root=${{ inputs.repo-root }}
-          --version=${{ inputs.version }}
-          --verbosity=${{ inputs.verbosity }}
-          --lines-changed-only=${{ inputs.lines-changed-only }}
-          --files-changed-only=${{ inputs.files-changed-only }}
-          --thread-comments=${{ inputs.thread-comments }}
-          --no-lgtm=${{ inputs.no-lgtm }}
-          --step-summary=${{ inputs.step-summary }}
-          --ignore="${{ inputs.ignore }}"
-          --ignore-tidy="${{ inputs.ignore-tidy }}"
-          --ignore-format="${{ inputs.ignore-format }}"
-          --database=${{ inputs.database }}
-          --file-annotations=${{ inputs.file-annotations }}
-          --extra-arg="${{ inputs.extra-args }}"
-          --tidy-review="${{ inputs.tidy-review }}"
-          --format-review="${{ inputs.format-review }}"
-          --passive-reviews="${{ inputs.passive-reviews }}"
-          --jobs=${{ inputs.jobs }}
+          '--style=${{ inputs.style }}'
+          --extensions '${{ inputs.extensions }}'
+          '--tidy-checks=${{ inputs.tidy-checks }}'
+          --repo-root ${{ inputs.repo-root }}
+          --version ${{ inputs.version }}
+          --verbosity ${{ inputs.verbosity }}
+          --lines-changed-only ${{ inputs.lines-changed-only }}
+          --files-changed-only ${{ inputs.files-changed-only }}
+          --thread-comments ${{ inputs.thread-comments }}
+          --no-lgtm ${{ inputs.no-lgtm }}
+          --step-summary ${{ inputs.step-summary }}
+          '--ignore=${{ inputs.ignore }}'
+          '--ignore-tidy=${{ inputs.ignore-tidy }}'
+          '--ignore-format=${{ inputs.ignore-format }}'
+          --database ${{ inputs.database }}
+          --file-annotations ${{ inputs.file-annotations }}
+          '--extra-arg=${{ inputs.extra-args }}'
+          --tidy-review ${{ inputs.tidy-review }}
+          --format-review ${{ inputs.format-review }}
+          --passive-reviews ${{ inputs.passive-reviews }}
+          --jobs ${{ inputs.jobs }}
         ]
         mut uv_args = [run --no-sync --project $action_path --directory (pwd)]
 


### PR DESCRIPTION
resolves #321
resolves #323

In nushell, quotes are not required for strings. Quotes were previously used around `inputs.*` values if they might

- contain spaces
- begin with `-`

This resulted in unnecessary quotes around the arg value passed to cpp-linter (`--ignore="build"`) which was causing the undesirable behavior in both #323 and #323.

After testing this in the test repo, it looks like the best way is 
```diff
-    --extra-args="${{ inputs.extra-args }}"
+    '--extra-args=${{ inputs.extra-args }}'
```

Nushell will now pass the entire string (`'--extra-arg=${{ inputs.extra-arg }}'`) as 1 arg to cpp-linter. Any space(s) are included as part of the arg value (as intended). For example:

- `--extra-arg=-std=c++14 -Wall` invokes `clang-tidy --extra-arg=-std=c++14 --extra-arg=-Wall`

> [!note]
> In the cpp-linter source, the `extra-arg` value is stripped of surrounding quotes because bash and pwsh have very different behavior in each.

This pattern also supports values that might begin with `-` or be an empty string. For example:

- `--style=` disables clang-format (as intended)
- `--tidy-checks=-*` disables clang-tidy (as intended)
- `--tidy-checks=` uses .clang-tidy file (as instended) if present

For the `ignore*` inputs, the quotes were causing paths to not match the discovered paths/files in a user's project. In cpp-linter source, there is _some_ stripping of space(s), but there is no stripping of quotes. This is intended to allow users to specify patterns like so:

```yml
    with:
      ignore: >-
        | build
        | ! src
```

which is behaviorally equivalent to

```yml
    with:
      ignore: '|build|!src'
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cpp-linter argument handling for consistent cross-shell parsing of style, check, ignore, verbosity, change-only, thread-comment, summary, job and annotation options.

* **Chores**
  * Workflow dependency install now excludes development packages and uses a safer link-mode to reduce install size and conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->