### PR TITLE
Update thread-comments condition in self-test.yml

### DIFF
--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -62,9 +62,9 @@ jobs:
           database: build
           verbosity: debug
           version: ${{ matrix.clang-version }}
-          thread-comments: ${{ github.event_name == 'pull_request' && matrix.clang-version == '12' && 'update' }}
-          file-annotations: ${{ runner.os == 'Linux' && matrix.clang-version == '12' }}
-          step-summary: ${{ matrix.clang-version == '12' }}
+          thread-comments: ${{ github.event_name == 'pull_request' && matrix.clang-version == '16' && 'update' }}
+          file-annotations: ${{ runner.os == 'Linux' && matrix.clang-version == '16' }}
+          step-summary: ${{ matrix.clang-version == '16' }}
           extra-args: -std=c++14 -Wall
 
       - name: Fail fast?!


### PR DESCRIPTION
Right now merge PR will be added thread-comments, see https://github.com/cpp-linter/cpp-linter-action/commit/b20a30fb194b1f5ef1469c8085a6e4d5b93f7443

I would like to disable it for merged commits.