### PR TITLE
chore: adjust docs CI triggers

### DIFF
--- a/.github/workflows/mkdocs-deploy.yml
+++ b/.github/workflows/mkdocs-deploy.yml
@@ -2,6 +2,9 @@ name: MkDocs Deploy
 
 on:
   push:
+    branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
- only build docs for PRs and pushes to main
- only deploys docs from main branch

> [!note]
> This is really just designed to stop building docs on every push to every branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated documentation deployment workflow to run only for changes on the main branch, reducing unnecessary runs and improving reliability.
  - Added checks on pull requests targeting the main branch to validate documentation build before merging.
  - Manual run option remains available for on-demand deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->