### PR TITLE
fix: update dependabot.yml to add `applies-to`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,9 +27,7 @@ updates:
           - "mypy"
           - "pre-commit"
           - "ruff"
-        update-types:
-          - "major"
-          - "minor"
+        applies-to: "security-updates"
       docs:
         patterns:
           - "mkdocs-gen-files"
@@ -38,6 +36,4 @@ updates:
           - "mkdocs-material"
           - "mkdocs"
           - "pyyaml"
-        update-types:
-          - "major"
-          - "minor"
+        applies-to: "security-updates"


### PR DESCRIPTION
I am not sure how `exclude-patterns` works with a group, but it seems `applies-to: "security-updates"` seems to work from this example 

https://github.com/hashicorp/golang-lru/blob/1ecdc13547b564bf736db9161ed89f1864010108/.github/dependabot.yml#L19-L36

closes #337 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update policy to apply security-only updates for developer tooling and documentation packages.
  * Reduces noise from routine version bumps, focusing maintenance on critical security patches.
  * Helps keep the project stable and secure without frequent non-essential update PRs.
  * No changes to app functionality; end-users should see no behavioral differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->