### PR TITLE
fix: enhance version input handling

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,9 +39,10 @@ inputs:
   version:
     description: |
       The desired version of the [clang-tools](https://github.com/cpp-linter/clang-tools-pip) to use.
-      Accepted options are strings which can be 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12 or 11.
+      Accepted options include major versions like 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12 or 11.
 
       - Set this option to a blank string (`''`) to use the platform's default installed version.
+      - Semantic version strings like `20.1` or `20.1.7` are also supported.
       - This value can also be a path to where the clang tools are installed (if using a custom install location).
     required: false
     default: '20'
@@ -384,13 +385,17 @@ runs:
         let version = try {
           $version_str | into int
         } catch {
-          print "Version is not an integer"
-          if not ($version_str | path exists) {
-            print "::error title=Invalid version input::Version must be a blank string, an integer, or a valid path"
-            exit 1
-          } else {
-            print $"(ansi yellow)Using custom clang tools installation at path: ($version_str)(ansi reset)"
-            exit 0
+          try {
+            $version_str | split row '.' | first | into int
+          } catch {
+            print "Version does not have an integer major component"
+            if not ($version_str | path exists) {
+              print "::error title=Invalid version input::Version must be a blank string, an integer, a semantic version string, or a valid path"
+              exit 1
+            } else {
+              print $"(ansi yellow)Using custom clang tools installation at path: ($version_str)(ansi reset)"
+              exit 0
+            }
           }
         }
 
@@ -411,7 +416,13 @@ runs:
 
         print $"\n(ansi purple)Ensuring ($tools | str join ' and ') ($version_str) are present(ansi reset)"
         for tool in $tools {
-          print $"Installing ($tool) ($version)"
+          let installed_tool = $"($tool)-($version_str)"
+          if not ((which $installed_tool) | is-empty) {
+            print $"(ansi yellow)Using existing ($installed_tool) from a prior installation source(ansi reset)"
+            continue
+          }
+
+          print $"Installing ($tool) ($version_str)"
           let cmd = if (
             (($version < 13) and ($tool | str ends-with "tidy"))
             or (
@@ -420,9 +431,9 @@ runs:
               and not ((version | get "build_os") | str starts-with "linux")
             )
           ) {
-            [clang-tools --tool $tool --install $version]
+            [clang-tools --tool $tool --install $version_str]
           } else {
-            [clang-tools-wheel --tool $tool --version $version]
+            [clang-tools-wheel --tool $tool --version $version_str]
           }
           ^$'($env.UV_INSTALL_DIR)/uv' ...$uv_args ...$cmd
         }


### PR DESCRIPTION
The following review suggestion comes from Codex

---

• The new installer flow introduces at least two functional regressions: it rejects valid
  semantic version inputs and it can fail after a successful package-manager install
  because fallback installers are invoked unconditionally. Those cases make the composite
  action less reliable than the base branch.

  Full review comments:

  - [P2] Preserve semantic version strings for tool installation — /Users/sxp/Repos/cpp-
    linter/cpp-linter-action/action.yml:384-390
    This now hard-fails any version like 20.1 or 20.1.7 unless it happens to be an existing
    path. That is a regression from the previous clang-tools -i ${{ inputs.version }}
    behavior: both the clang-tools and clang-tools-wheel CLIs accept semantic version
    specifications, and cpp-linter itself resolves dotted versions when selecting clang-
    format/clang-tidy. Workflows that pin an exact wheel/build version will now stop here
    with Invalid version input instead of installing the requested tool.
  - [P2] Stop after the first successful tool source — /Users/sxp/Repos/cpp-linter/cpp-
    linter-action/action.yml:412-427
    On Linux and macOS this loop runs even when the earlier apt/Homebrew step has already
    installed the requested clang tool. As a result, a later PyPI/static install failure
    will now fail the action even though clang-format-$version/clang-tidy-$version is
    already present, which breaks the documented “try sources in order” fallback behavior.
    The secondary installers should only run when the prior source did not yield a usable
    tool.