### PR TITLE
docs: add cross-reference to cpp-linter-hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ workflow [`step-summary`][step-summary], and Pull Request reviews (with
 
 > [!TIP]
 > Prefer pre-commit hooks over GitHub Actions? Check out
-> **[cpp-linter-hooks](https://github.com/cpp-linter/cpp-linter-hooks)** —
+> [**cpp-linter-hooks**](https://github.com/cpp-linter/cpp-linter-hooks) —
 > a pre-commit hook repository that runs `clang-format` and `clang-tidy`
 > consistently on developer machines and in CI, with no manual LLVM installs.
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ to collect feedback provided in the form of
 workflow [`step-summary`][step-summary], and Pull Request reviews (with
 [`tidy-review`][tidy-review] or [`format-review`][format-review]).
 
+> [!TIP]
+> Prefer pre-commit hooks over GitHub Actions? Check out
+> **[cpp-linter-hooks](https://github.com/cpp-linter/cpp-linter-hooks)** —
+> a pre-commit hook repository that runs `clang-format` and `clang-tidy`
+> consistently on developer machines and in CI, with no manual LLVM installs.
+
 ## Usage
 
 Create a new GitHub Actions workflow in your project, e.g. at [.github/workflows/cpp-linter.yml](https://github.com/cpp-linter/cpp-linter-action/blob/main/.github/workflows/cpp-linter.yml)


### PR DESCRIPTION
Add a TIP callout in the README recommending [cpp-linter-hooks](https://github.com/cpp-linter/cpp-linter-hooks) for users who prefer pre-commit hooks over GitHub Actions, with bidirectional cross-linking between the two projects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new tip in the README recommending users explore the `cpp-linter-hooks` pre-commit hook repository as an alternative to GitHub Actions. This option provides consistent C++ linting with clang-format and clang-tidy without requiring manual LLVM installation, delivering a simplified setup experience. Users can now make an informed choice based on their workflow needs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->