### PR TITLE
docs: change primary color from blue to indigo

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -2,11 +2,6 @@ th {
     background-color: var(--md-default-fg-color--lightest);
 }
 
-.md-header,
-.md-nav--primary .md-nav__title[for="__drawer"] {
-    background-color: #4051b5;
-}
-
 @keyframes heart {
 
     0%,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,7 +34,7 @@ theme:
   palette:
     # Palette toggle for automatic mode
     - media: "(prefers-color-scheme)"
-      primary: blue
+      primary: indigo
       accent: cyan
       toggle:
         icon: material/brightness-auto
@@ -43,7 +43,7 @@ theme:
     # Palette toggle for light mode
     - media: "(prefers-color-scheme: light)"
       scheme: default
-      primary: blue
+      primary: indigo
       accent: cyan
       toggle:
         icon: material/lightbulb-outline
@@ -52,7 +52,7 @@ theme:
     # Palette toggle for dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
-      primary: blue
+      primary: indigo
       accent: cyan
       toggle:
         icon: material/lightbulb


### PR DESCRIPTION
## Summary

Unify the MkDocs primary color with the cpp-linter.github.io hub site.

- Changed `primary: blue` → `primary: indigo` across all three palette modes
- Indigo matches the cpp-linter organization logo and brand identity
- The extra.css already uses `#4051b5` (indigo) for mobile nav — now palette matches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the documentation theme primary color from blue to indigo across automatic, light, and dark modes for improved visual consistency.
  * Removed a custom header/background color override to align header appearance with the new theme palette.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->