### PR TITLE
docs: add back-navigation link to cpp-linter hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@
 [![cpp-linter](https://github.com/cpp-linter/cpp-linter-action/actions/workflows/cpp-linter.yml/badge.svg)](https://github.com/cpp-linter/cpp-linter-action/actions/workflows/cpp-linter.yml)
 [![MkDocs Deploy](https://github.com/cpp-linter/cpp-linter-action/actions/workflows/mkdocs-deploy.yml/badge.svg)](https://github.com/cpp-linter/cpp-linter-action/actions/workflows/mkdocs-deploy.yml)
 ![GitHub](https://img.shields.io/github/license/cpp-linter/cpp-linter-action?label=license&logo=github)
-
-> [![cpp-linter hub](https://img.shields.io/badge/%F0%9F%8F%A0_cpp--linter_hub-%E2%86%90_home-22863a)](https://cpp-linter.github.io/)
+[![cpp-linter hub](https://img.shields.io/badge/%F0%9F%8F%A0_cpp--linter_hub-%E2%86%90_home-22863a)](https://cpp-linter.github.io/)
 
 A Github Action for linting C/C++ code integrating clang-tidy and clang-format
 to collect feedback provided in the form of

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 [![MkDocs Deploy](https://github.com/cpp-linter/cpp-linter-action/actions/workflows/mkdocs-deploy.yml/badge.svg)](https://github.com/cpp-linter/cpp-linter-action/actions/workflows/mkdocs-deploy.yml)
 ![GitHub](https://img.shields.io/github/license/cpp-linter/cpp-linter-action?label=license&logo=github)
 
-> 🏠 [← Back to cpp-linter hub](https://cpp-linter.github.io/)
+> [![cpp-linter hub](https://img.shields.io/badge/%F0%9F%8F%A0_cpp--linter_hub-%E2%86%90_home-22863a)](https://cpp-linter.github.io/)
 
 A Github Action for linting C/C++ code integrating clang-tidy and clang-format
 to collect feedback provided in the form of

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@
 [![MkDocs Deploy](https://github.com/cpp-linter/cpp-linter-action/actions/workflows/mkdocs-deploy.yml/badge.svg)](https://github.com/cpp-linter/cpp-linter-action/actions/workflows/mkdocs-deploy.yml)
 ![GitHub](https://img.shields.io/github/license/cpp-linter/cpp-linter-action?label=license&logo=github)
 
+> 🏠 [← Back to cpp-linter hub](https://cpp-linter.github.io/)
+
 A Github Action for linting C/C++ code integrating clang-tidy and clang-format
 to collect feedback provided in the form of
 [`file-annotations`][file-annotations], [`thread-comments`][thread-comments],

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ nav:
   - permissions.md
   - examples/index.md
   - contributing-guidelines.md
+  - "← cpp-linter hub": https://cpp-linter.github.io/
 
 theme:
   name: material

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,7 +11,7 @@ nav:
   - permissions.md
   - examples/index.md
   - contributing-guidelines.md
-  - ":material-arrow-left: cpp-linter org": https://cpp-linter.github.io/
+  - "← cpp-linter org": https://cpp-linter.github.io/
 
 theme:
   name: material

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,7 +11,7 @@ nav:
   - permissions.md
   - examples/index.md
   - contributing-guidelines.md
-  - "← cpp-linter hub": https://cpp-linter.github.io/
+  - ":material-arrow-left: cpp-linter org": https://cpp-linter.github.io/
 
 theme:
   name: material


### PR DESCRIPTION
Adds `← Back to cpp-linter hub` navigation link in both:\n- The MkDocs site nav\n- The README.md\n\nThis makes it easy for users to navigate back to the central hub from the cpp-linter-action documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "cpp-linter hub" badge/link to the project README header.
  * Updated site navigation to include a link to the cpp-linter hub, making the external hub more discoverable from the documentation site.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->