### PR TITLE
docs: remove license badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@
 [![GitHub marketplace](https://img.shields.io/badge/marketplace-C%2FC%2B%2B%20Linter-blue?logo=github)](https://github.com/marketplace/actions/c-c-linter)
 [![cpp-linter](https://github.com/cpp-linter/cpp-linter-action/actions/workflows/cpp-linter.yml/badge.svg)](https://github.com/cpp-linter/cpp-linter-action/actions/workflows/cpp-linter.yml)
 [![MkDocs Deploy](https://github.com/cpp-linter/cpp-linter-action/actions/workflows/mkdocs-deploy.yml/badge.svg)](https://github.com/cpp-linter/cpp-linter-action/actions/workflows/mkdocs-deploy.yml)
-![GitHub](https://img.shields.io/github/license/cpp-linter/cpp-linter-action?label=license&logo=github)
 [![cpp-linter hub](https://img.shields.io/badge/%F0%9F%8F%A0_cpp--linter_hub-%E2%86%90_home-22863a)](https://cpp-linter.github.io/)
 
 A Github Action for linting C/C++ code integrating clang-tidy and clang-format


### PR DESCRIPTION
Before 

<img width="849" height="171" alt="image" src="https://github.com/user-attachments/assets/5913d25f-7e2b-4aa3-882d-edcd4a19989e" />

After

<img width="896" height="144" alt="image" src="https://github.com/user-attachments/assets/71345023-b844-49d9-a94f-40efec645dc7" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the GitHub license status badge from the README header section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->