### PR TITLE
chore: drop clang 11 support and update default version to 21

### DIFF
--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        clang-version: ['11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22']
+        clang-version: ['12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22']
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/action.yml
+++ b/action.yml
@@ -39,12 +39,12 @@ inputs:
   version:
     description: |
       The desired version of the [clang-tools](https://github.com/cpp-linter/clang-tools-pip) to use.
-      Accepted options are strings which can be 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12 or 11.
+      Accepted options are strings which can be 22, 21, 20, 19, 18, 17, 16, 15, 14, 13 or 12.
 
       - Set this option to a blank string (`''`) to use the platform's default installed version.
       - This value can also be a path to where the clang tools are installed (if using a custom install location).
     required: false
-    default: '20'
+    default: '21'
   verbosity:
     description: |
       This controls the action's verbosity in the workflow's logs.


### PR DESCRIPTION
## Summary

This PR drops support for **clang version 11** and updates the **default clang version** from 20 to 21.

## Changes

1. **`action.yml`** — Removed `11` from the list of accepted version strings and updated the default from `'20'` to `'21'`.
2. **`.github/workflows/self-test.yml`** — Removed `'11'` from the clang-version test matrix.

## Motivation

Clang 11 is now several years old and is no longer actively maintained in the clang-tools-pip ecosystem. Clang 21 is the latest major version and should be the default going forward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the supported toolchain version range to start at a newer minimum version.
  * Changed the default clang-tools version to a newer release.
  * The self-test workflow now runs against the updated version matrix, improving consistency with current supported versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->