### PR TITLE
chore(deps): fix Dependabot groups so dev/docs deps update in one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,22 +21,21 @@ updates:
     open-pull-requests-limit: 10
     groups:
       org:
-        # updates about org-maintained packages
+        # org-maintained packages (the "action" dependency group)
+        applies-to: version-updates
         patterns:
-          - "*"
-        exclude-patterns:
-          - "mypy*"
-          - "pre-commit*"
-          - "ruff*"
-          - "mkdocs*"
-          - "pyyaml*"
+          - "clang-tools"
+          - "cpp-linter"
       dev:
-        # updates about everything else (dev and docs)
+        # everything else: dev tooling + docs (major/minor/patch all in one PR)
+        applies-to: version-updates
         patterns:
           - "*"
         exclude-patterns:
-          - "clang-tools*"
-          - "cpp-linter*"
-        update-types:
-          - major
-          - minor
+          - "clang-tools"
+          - "cpp-linter"
+      security:
+        # keep security fixes grouped too (previously happened only by accident)
+        applies-to: security-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
## Why

Dependabot keeps opening one PR per dev dependency (currently #474 for mypy and #478 for ruff) although `dependabot.yml` defines a `dev` group.

Root cause, taken from the Dependabot job logs (Insights → Dependency graph → Dependabot → uv.lock):

- Every weekly **version-update** job only carries the `org` group (`Found 1 group(s)`). The `dev` group is absent from the job definition.
- **Security-update** jobs do carry `dev`, with `"applies-to": "security-updates"`.
- #345 set `applies-to: security-updates` on `dev`; #353 removed the key, but GitHub kept the old value while refreshing the other rules. `org` was a new group name in #353, so it got the default.
- That is why every "bump the dev group" PR so far (#407, #421, #431, #447, #468) came from a security advisory, and why even major/minor bumps of mypy (#435, #461) were opened individually.

Two smaller issues fixed on the way:

- `update-types: [major, minor]` would have excluded patch bumps from the group anyway. dependabot-core opens an individual PR for any level not listed, which is exactly the #474/#478 case.
- `org` used `*` plus `exclude-patterns`, so `markdown-gfm-admonition` was being assigned to the `org` group (visible in the logs).

## What changed

- `org`: explicit `applies-to: version-updates`, exact patterns `clang-tools` and `cpp-linter`.
- `dev`: explicit `applies-to: version-updates`, no `update-types`, so major/minor/patch bumps of everything else land in one PR.
- New `security` group (`applies-to: security-updates`, `*`) so security fixes stay grouped. Until now that only happened by accident. Drop it if individual security PRs are preferred.

## How to verify

Merging triggers a uv job right away. Its log should say `Found 2 group(s)` and Dependabot should open a single "bump the dev group with N updates" PR; #474 and #478 then get superseded.

Fallback: if the log still reports one group, rename `dev`. GitHub appears to key the stale value on the group name, so a new name starts clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update grouping for clearer handling of development and tooling packages.
  * Added a dedicated group for security-related dependency updates.
  * Adjusted update scopes to distinguish version updates from security updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->